### PR TITLE
商品詳細表示の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @user = User.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @user = User.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -47,7 +47,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @user.nickname %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,21 +7,21 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <% if item.image.attached? %>
-      <%= image_tag item.image ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <% if item.order %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <% end %>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
-      <% end %>
+        <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+        <%# if item.order %>
+        <%# <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+        <% end %>
+        <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%# ¥ 999,999,999 %>
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -47,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charges.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
TOPページから商品写真をクリックすると詳細ページへ遷移する
- ログアウト状態でも商品詳細ページを閲覧できること
- 商品出品時に登録した情報が見られるようになっていること

キャプチャ画像
https://i.gyazo.com/82a5348fd1c38536af17c0aaaefed540.png
https://i.gyazo.com/998539632b15ccb45c6c25b5aa1f71b4.png
https://i.gyazo.com/974600ffdb66e6641405a9b9c9ec2e75.png

※編集・削除ページへの遷移はそれぞれのブランチで作業します。